### PR TITLE
Bump minimal-notebook tag in Dockerfile.

### DIFF
--- a/template/Dockerfile.template
+++ b/template/Dockerfile.template
@@ -1,7 +1,7 @@
 # (c) Copyright IBM Corp. 2016.  All Rights Reserved.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/minimal-notebook:9f9907cf1df8
+FROM jupyter/minimal-notebook:2d878db5cbff
 
 MAINTAINER zos-spark/zspeak-dev
 


### PR DESCRIPTION
New version pulls in latest release of Conda (4.x), which fixes build
issue due to Conda pulling in wrong dependencies.
